### PR TITLE
Update nes css url to use git cdn

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -15,7 +15,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 <script src="https://rawgit.com/jeremyckahn/shifty/gh-pages/shifty.js" crossorigin="anonymous"></script>
-<link href="{% static "css/nes.min.css" %}" rel="stylesheet" crossorigin="anonymous"/>
+<link href="https://ghcdn.rawgit.org/sadmoody/covid-predictor/master/static/css/nes.min.css" rel="stylesheet" crossorigin="anonymous"/>
 <link href="https://cdn.jsdelivr.net/gh/nostalgic-css/NES.css@2.3.0/docs/lib/dialog-polyfill.css" rel="stylesheet" crossorigin="anonymous"/>
 <script src="https://cdn.jsdelivr.net/gh/nostalgic-css/NES.css@2.3.0/docs/lib/dialog-polyfill.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/gh/nostalgic-css/NES.css@2.3.0/docs/lib/vue.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
Removed static asset loading from jsdelivr and moved to rawgit's service